### PR TITLE
Add browserInfo tab feature

### DIFF
--- a/src/modules/code-generator/base-generator.js
+++ b/src/modules/code-generator/base-generator.js
@@ -19,7 +19,6 @@ export default class BaseGenerator {
   }
 
   _parseEvents(events) {
-    console.log(events)
     let result = ''
 
     if (!events) return result
@@ -37,7 +36,6 @@ export default class BaseGenerator {
           this._blocks.push(this._handleClick(tagName, text))
           break
         case 'change':
-          console.log(tagName)
           if (tagName === 'SELECT') {
             this._blocks.push(this._handleChange(escapedSelector, value, text))
           }

--- a/src/modules/code-generator/browserInfo.js
+++ b/src/modules/code-generator/browserInfo.js
@@ -1,0 +1,47 @@
+// browserInfo.js
+
+// Collect the browser info related to the recent RepSteps list
+
+import BaseGenerator from '@/modules/code-generator/base-generator'
+import { headlessActions } from '@/modules/code-generator/constants'
+
+export default class BrowserInfoGenerator extends BaseGenerator {
+  constructor(options) {
+    super(options)
+  }
+
+  _parseEvents(events) {
+    let result = ''
+
+    if (!events) return result
+    for (let i = 0; i < events.length; i++) {
+      const { action, selector, value, href, keyCode, tagName, text } = events[i]
+      const escapedSelector = selector ? selector?.replace(/\\/g, '\\\\') : selector
+
+      switch (action) {
+        case headlessActions.VIEWPORT:
+          this._blocks.unshift(
+            this._handleViewport(value.windowWidth, value.windowHeight, value.browserVendor)
+          )
+          break
+      }
+    }
+
+    this._postProcess()
+
+    const newLine = `\n`
+
+    for (let block of this._blocks) {
+      const lines = block.getLines()
+      for (let line of lines) {
+        result += line.value + newLine
+      }
+    }
+
+    return result
+  }
+
+  generate(events) {
+    return this._parseEvents(events)
+  }
+}

--- a/src/modules/code-generator/browserInfo.js
+++ b/src/modules/code-generator/browserInfo.js
@@ -15,8 +15,7 @@ export default class BrowserInfoGenerator extends BaseGenerator {
 
     if (!events) return result
     for (let i = 0; i < events.length; i++) {
-      const { action, selector, value, href, keyCode, tagName, text } = events[i]
-      const escapedSelector = selector ? selector?.replace(/\\/g, '\\\\') : selector
+      const { action, value } = events[i]
 
       switch (action) {
         case headlessActions.VIEWPORT:

--- a/src/modules/code-generator/constants.js
+++ b/src/modules/code-generator/constants.js
@@ -18,4 +18,5 @@ export const eventsToRecord = {
 
 export const headlessTypes = {
   REPSTEPS: 'repSteps',
+  BROWSERINFO: 'Browser Info'
 }

--- a/src/modules/code-generator/index.js
+++ b/src/modules/code-generator/index.js
@@ -1,13 +1,16 @@
 import RepStepListGenerator from '@/modules/code-generator/repSteps'
+import BrowserInfoListGenerator from '@/modules/code-generator/browserInfo'
 
 export default class CodeGenerator {
   constructor(options = {}) {
     this.repStepGenerator = new RepStepListGenerator(options)
+    this.browserInfoGenerator = new BrowserInfoListGenerator(options)
   }
 
   generate(recording) {
     return {
       repSteps: this.repStepGenerator.generate(recording),
+      browserInfo: this.browserInfoGenerator.generate(recording),
     }
   }
 }

--- a/src/modules/code-generator/repSteps.js
+++ b/src/modules/code-generator/repSteps.js
@@ -1,12 +1,56 @@
-// import Block from '@/modules/code-generator/block'
-// import { headlessActions } from '@/modules/code-generator/constants'
+import Block from '@/modules/code-generator/block'
+import { headlessActions } from '@/modules/code-generator/constants'
 import BaseGenerator from '@/modules/code-generator/base-generator'
-
-// const repStepsDescription = `rep step descriptions`
 
 export default class RepStepListGenerator extends BaseGenerator {
   constructor(options) {
     super(options)
+  }
+
+  _parseEvents(events) {
+    let result = ''
+
+    if (!events) return result
+    for (let i = 0; i < events.length; i++) {
+      const { action, selector, value, href, keyCode, tagName, text } = events[i]
+      const escapedSelector = selector ? selector?.replace(/\\/g, '\\\\') : selector
+
+      switch (action) {
+        case 'keydown':
+          if (keyCode === this._options.keyCode) {
+            this._blocks.push(this._handleKeyDown(value))
+          }
+          break
+        case 'click':
+          this._blocks.push(this._handleClick(tagName, text))
+          break
+        case 'change':
+          if (tagName === 'SELECT') {
+            this._blocks.push(this._handleChange(escapedSelector, value, text))
+          }
+          break
+        case headlessActions.NAVIGATION:
+          this._blocks.push(this._handleNavigation(href))
+          this._hasNavigation = true
+          break
+        case headlessActions.SCREENSHOT:
+          this._blocks.push(this._handleScreenshot(value))
+          break
+      }
+    }
+
+    this._postProcess()
+
+    const newLine = `\n`
+
+    for (let block of this._blocks) {
+      const lines = block.getLines()
+      for (let line of lines) {
+        result += line.value + newLine
+      }
+    }
+
+    return result
   }
 
   generate(events) {

--- a/src/modules/code-generator/repSteps.js
+++ b/src/modules/code-generator/repSteps.js
@@ -1,4 +1,3 @@
-import Block from '@/modules/code-generator/block'
 import { headlessActions } from '@/modules/code-generator/constants'
 import BaseGenerator from '@/modules/code-generator/base-generator'
 

--- a/src/popup/PopupApp.vue
+++ b/src/popup/PopupApp.vue
@@ -16,6 +16,7 @@
 
     <Results
       :repSteps="codeForRepSteps"
+      :browserInfo="codeForbrowserInfo"
       :options="options"
       v-if="showResultsTab"
       v-on:update:tab="currentResultTab = $event"
@@ -94,6 +95,7 @@ export default {
       liveEvents: [],
       recording: [],
       codeForRepSteps: '',
+      codeForbrowserInfo: '',
       options: defaultOptions,
     }
   },
@@ -154,6 +156,7 @@ export default {
     cleanUp() {
       this.recording = this.liveEvents = []
       this.codeForRepSteps = ''
+      this.codeForbrowserInfo = ''
       this.showResultsTab = this.isRecording = this.isPaused = false
       this.storeState()
     },
@@ -161,10 +164,11 @@ export default {
     async generateCode() {
       const { recording, options = { code: {} } } = await storage.get(['recording', 'options'])
       const generator = new CodeGenerator(options.code)
-      const { repSteps } = generator.generate(recording)
+      const { repSteps, browserInfo } = generator.generate(recording)
 
       this.recording = recording
       this.codeForRepSteps = repSteps
+      this.codeForbrowserInfo = browserInfo
       this.showResultsTab = true
     },
 
@@ -178,6 +182,7 @@ export default {
         controls = {},
         options,
         codeForRepSteps = '',
+        codeForbrowserInfo = '',
         recording,
         clear,
         pause,
@@ -186,6 +191,7 @@ export default {
         'controls',
         'options',
         'codeForRepSteps',
+        'codeForbrowserInfo',
         'recording',
         'clear',
         'pause',
@@ -196,6 +202,7 @@ export default {
       this.isPaused = controls.isPaused
       this.options = options || defaultOptions
       this.codeForRepSteps = codeForRepSteps
+      this.codeForbrowserInfo = codeForbrowserInfo
 
       if (this.isRecording) {
         this.liveEvents = recording
@@ -223,6 +230,7 @@ export default {
     storeState() {
       storage.set({
         codeForRepSteps: this.codeForRepSteps,
+        codeForbrowserInfo: this.codeForbrowserInfo,
         controls: { isRecording: this.isRecording, isPaused: this.isPaused },
       })
     },
@@ -239,7 +247,8 @@ export default {
     },
 
     getCode() {
-      return this.codeForRepSteps
+      // console.log("hello " + this.codeForbrowserInfo)
+      return this.currentResultTab === 'repSteps' ? this.codeForRepSteps : this.codeForbrowserInfo
     },
   },
 }

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -44,6 +44,10 @@ export default {
       type: String,
       default: '',
     },
+    browserInfo: {
+      type: String,
+      default: '',
+    },
     options: {
       type: Object,
       default: () => ({}),
@@ -53,13 +57,13 @@ export default {
   data() {
     return {
       activeTab: headlessTypes.REPSTEPS,
-      tabs: [headlessTypes.REPSTEPS],
+      tabs: [headlessTypes.REPSTEPS, headlessTypes.BROWSERINFO],
     }
   },
 
   computed: {
     code: function() {
-      return this.repSteps
+      return this.activeTab === headlessTypes.REPSTEPS ? this.repSteps : this.browserInfo
     },
   },
 


### PR DESCRIPTION
# Pull Request Template

## Why?
 _What is the problem this PR attempts to solve, and why is it important? Feature? Bug fix?_ 

Currently the browser information and the replication steps were combined together. This looked cluttered. 

## What?
_What does this PR change and how does it solve the problem noted above?_ 

1. We added a new tab that just looks at the viewport information. 

2. We also separated out the replication steps code to just focus on that and not include the viewport code.

## Testing Notes
_Set the stage for the Reviewer_

### Setup/Preperation
_Is any special setup required for testing this change?_
None

### Feature Testing Steps
_List all the necessary steps to review and test this change._

- [ ] Click browser extension icon
- [ ] click on an element on the current web page
- [ ] Click Stop
- [ ] Click icon 
Result:
First tab should be RepSteps
 - should not include browser information
 - [ ] Click tab "Browser Info"
 - should display text like below
 ```
BrowserInfo:
  Broswer Vendor: Google Inc.
  Window size: width: 1440, height: 714
```

## Checklist:

- [ ] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
