### PR TITLE
add spaces between blocks

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -12,7 +12,6 @@ import { ref } from 'vue'
 import { version } from '../../package.json'
 
 export default {
-
   setup() {
     return {
       version: ref(version),

--- a/src/components/__tests__/ResultsTab.spec.js
+++ b/src/components/__tests__/ResultsTab.spec.js
@@ -30,9 +30,7 @@ describe('RecordingTab.vue', () => {
     const wrapper = await mount(ResultsTab, {
       props: {
         options: {
-          code: {
-            
-          },
+          code: {},
         },
       },
     })

--- a/src/modules/code-generator/base-generator.js
+++ b/src/modules/code-generator/base-generator.js
@@ -70,9 +70,7 @@ export default class BaseGenerator {
   }
 
   _postProcess() {
-    if (this._options.blankLinesBetweenBlocks && this._blocks.length > 0) {
       this._postProcessAddBlankLines()
-    }
   }
 
   _handleKeyDown(value) {
@@ -91,10 +89,15 @@ export default class BaseGenerator {
         type: eventsToRecord.CLICK,
         value: `Click inside ${tagName} field`,
       })
+    } else if (tagName === ('A' || 'LINK')){
+      block.addLine({
+        type: eventsToRecord.CLICK,
+        value: `Click link with text: "${text}"`,
+      })
     } else {
       block.addLine({
         type: eventsToRecord.CLICK,
-        value: `Click ${tagName} tag with text: "${text}"`,
+        value: `Click text: "${text}"`,
       })
     }
     return block

--- a/src/modules/code-generator/base-generator.js
+++ b/src/modules/code-generator/base-generator.js
@@ -70,7 +70,7 @@ export default class BaseGenerator {
   }
 
   _postProcess() {
-      this._postProcessAddBlankLines()
+    this._postProcessAddBlankLines()
   }
 
   _handleKeyDown(value) {
@@ -89,7 +89,7 @@ export default class BaseGenerator {
         type: eventsToRecord.CLICK,
         value: `Click inside ${tagName} field`,
       })
-    } else if (tagName === ('A' || 'LINK')){
+    } else if (tagName === ('A' || 'LINK')) {
       block.addLine({
         type: eventsToRecord.CLICK,
         value: `Click link with text: "${text}"`,

--- a/src/modules/code-generator/constants.js
+++ b/src/modules/code-generator/constants.js
@@ -18,5 +18,5 @@ export const eventsToRecord = {
 
 export const headlessTypes = {
   REPSTEPS: 'repSteps',
-  BROWSERINFO: 'Browser Info'
+  BROWSERINFO: 'Browser Info',
 }

--- a/src/options/OptionsApp.vue
+++ b/src/options/OptionsApp.vue
@@ -65,7 +65,7 @@
 
       <section>
         <h2>Generator</h2>
- <!--   <Toggle v-model="options.code.blankLinesBetweenBlocks">
+        <!--   <Toggle v-model="options.code.blankLinesBetweenBlocks">
           Add blank lines between code blocks
         </Toggle> -->
       </section>

--- a/src/options/OptionsApp.vue
+++ b/src/options/OptionsApp.vue
@@ -65,13 +65,9 @@
 
       <section>
         <h2>Generator</h2>
-        <!-- <Toggle v-model="options.code.waitForSelectorOnClick">
-          Add <code>waitForSelector</code> lines before every
-          <code>page.click()</code>
-        </Toggle> -->
-        <Toggle v-model="options.code.blankLinesBetweenBlocks">
+ <!--   <Toggle v-model="options.code.blankLinesBetweenBlocks">
           Add blank lines between code blocks
-        </Toggle>
+        </Toggle> -->
       </section>
 
       <section>

--- a/src/services/__tests__/browser.spec.js
+++ b/src/services/__tests__/browser.spec.js
@@ -6,11 +6,7 @@ const copyText = {
   data: '',
 }
 
-const cookies = [
-  {
-    
-  },
-]
+const cookies = [{}]
 
 window.chrome = {
   tabs: {


### PR DESCRIPTION
# Pull Request Template

## Why?
 _What is the problem this PR attempts to solve, and why is it important? Feature? Bug fix?_ 
The generated list looking cluttered and difficult to read as all block lines were displayed one after the other without any delineation.

## What?
_What does this PR change and how does it solve the problem noted above?_
We've added a new line character `\n` to the end of each block line. This then creates space and easy read ability of replication steps.

## Testing Notes
### Setup/Preperation
_Is any special setup required for testing this change?_
No special set up

### Feature Testing Steps
_List all the necessary steps to review and test this change._
- [ ] Click RepSteps Icon
- [ ] Click record button
- [ ] Recording should start
- [ ] click on a couple elements on the page
- [ ] Stop the recording
- [ ] Record icon should now have a '1' indicator 
- [ ] click record icon
Result
Blocks should now present with spaces/ a new between them

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
