### PR TITLE
set repSteps as default

### DIFF
--- a/src/popup/PopupApp.vue
+++ b/src/popup/PopupApp.vue
@@ -91,7 +91,7 @@ export default {
       isRecording: false,
       isPaused: false,
       isCopying: false,
-      currentResultTab: null,
+      currentResultTab: 'repSteps',
       liveEvents: [],
       recording: [],
       codeForRepSteps: '',


### PR DESCRIPTION
# Pull Request Template

## Why?
 _What is the problem this PR attempts to solve, and why is it important? Feature? Bug fix?_ 
When clicking the Copy to Clipboard button on the Results Popup the copied text is just the Browser Info tab info and not the RepSteps as expected

## What?
_What does this PR change and how does it solve the problem noted above?_
We set the returned data default to `repSteps` to make sure that we are always returning the repSteps first.

## Testing Notes
### Setup/Preparation
None

### Testing Steps
_List all the necessary steps to review and test this change._
_Is any special setup required for testing this change?_
- [ ] click red button to start recording
- [ ] click around
- [ ] stop recording
- [ ] click icon in browser
- [ ] click copy to clipboard
RESULT: Copies the RepSteps tab info
- [ ] click BrowserInfo tab
RESULT: Copies the Browser Info tab 
- [ ] click back to RepSteps tab
- [ ] click copy to clipboard
RESULT: Copies the correct RepSteps info

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
